### PR TITLE
docs: update copyright year in footer automatically

### DIFF
--- a/packages/document/rspress.config.ts
+++ b/packages/document/rspress.config.ts
@@ -91,7 +91,7 @@ export default defineConfig({
   themeConfig: {
     enableAppearanceAnimation: false,
     footer: {
-      message: '© 2024 Bytedance Inc. All Rights Reserved.',
+      message: `© ${new Date().getFullYear()} Bytedance Inc. All Rights Reserved.`,
     },
     hideNavbar: 'auto',
     socialLinks: [


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Replace the hardcoded footer year with `new Date().getFullYear()` to keep the copyright year current automatically.