### PR TITLE
Update footer copyright date

### DIFF
--- a/packages/document/rspress.config.ts
+++ b/packages/document/rspress.config.ts
@@ -91,7 +91,7 @@ export default defineConfig({
   themeConfig: {
     enableAppearanceAnimation: false,
     footer: {
-      message: '© 2024 Bytedance Inc. All Rights Reserved.',
+      message: '© 2022-present ByteDance Inc.',
     },
     hideNavbar: 'auto',
     socialLinks: [


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Revise the footer message to show “© 2022-present ByteDance Inc.” instead of a fixed year.