### PR TITLE
test: add missing optional chaining and tsconfig.json

### DIFF
--- a/e2e/fixtures/dynamic-toc/index.test.ts
+++ b/e2e/fixtures/dynamic-toc/index.test.ts
@@ -1,7 +1,5 @@
 import { setTimeout } from 'node:timers/promises';
-
 import { expect, test } from '@playwright/test';
-
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 
 test.describe('dynamic toc', async () => {
@@ -25,21 +23,21 @@ test.describe('dynamic toc', async () => {
     });
 
     let h2 = await page.$('h2');
-    let text = await page.evaluate(h2 => h2?.textContent.trim(), h2);
+    let text = await page.evaluate(h2 => h2?.textContent?.trim(), h2);
     expect(text).toBe('#Term');
 
     let toc = await page.$('.aside-link');
-    let tocText = await page.evaluate(toc => toc?.textContent.trim(), toc);
+    let tocText = await page.evaluate(toc => toc?.textContent?.trim(), toc);
     expect(tocText).toBe('Term');
 
     await setTimeout(1000); // Wait for dynamic TOC to update
 
     h2 = await page.$('h2');
-    text = await page.evaluate(h2 => h2?.textContent.trim(), h2);
+    text = await page.evaluate(h2 => h2?.textContent?.trim(), h2);
     expect(text).toBe('#Term dynamic content');
 
     toc = await page.$('.aside-link');
-    tocText = await page.evaluate(toc => toc?.textContent.trim(), toc);
+    tocText = await page.evaluate(toc => toc?.textContent?.trim(), toc);
     expect(tocText).toBe('Term dynamic content');
   });
 });

--- a/e2e/fixtures/dynamic-toc/tsconfig.json
+++ b/e2e/fixtures/dynamic-toc/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "ES2020"],
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "bundler",
+    "useDefineForClassFields": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["docs", "theme", "rspress.config.ts"],
+  "mdx": {
+    "checkMdx": true
+  }
+}


### PR DESCRIPTION
## Summary by Sourcery

Introduce a TypeScript configuration for the dynamic-toc e2e fixture and harden its tests against null values by adding optional chaining.

Build:
- Add tsconfig.json for the dynamic-toc fixture with strict TypeScript compiler options.

Tests:
- Add optional chaining to textContent.trim calls in dynamic-toc e2e tests to guard against null elements.